### PR TITLE
avoid mutable default in aligner

### DIFF
--- a/tortoise/utils/wav2vec_alignment.py
+++ b/tortoise/utils/wav2vec_alignment.py
@@ -7,13 +7,15 @@ from transformers import Wav2Vec2ForCTC, Wav2Vec2FeatureExtractor, Wav2Vec2CTCTo
 from tortoise.utils.audio import load_audio
 
 
-def max_alignment(s1, s2, skip_character='~', record={}):
+def max_alignment(s1, s2, skip_character='~', record=None):
     """
     A clever function that aligns s1 to s2 as best it can. Wherever a character from s1 is not found in s2, a '~' is
     used to replace that character.
 
     Finally got to use my DP skills!
     """
+    if record is None:
+        record = {}
     assert skip_character not in s1, f"Found the skip character {skip_character} in the provided string, {s1}"
     if len(s1) == 0:
         return ''
@@ -145,4 +147,3 @@ class Wav2VecAlignment:
             start, stop = nri
             output_audio.append(audio[:, alignments[start]:alignments[stop]])
         return torch.cat(output_audio, dim=-1)
-


### PR DESCRIPTION
Thanks to Python's handling of mutable default arguments, having `record` default to an empty dict means that text can stick around from previous calls if you're calling the aligner in a loop (as I was). This can be avoided by creating a new dict inside the function where necessary.

Just noticed issue #65 — this might be the root cause there if multi-line inputs are the problem.