### PR TITLE
Fix gradient warning

### DIFF
--- a/tortoise/models/arch_util.py
+++ b/tortoise/models/arch_util.py
@@ -342,7 +342,7 @@ class CheckpointedLayer(nn.Module):
         for k, v in kwargs.items():
             assert not (isinstance(v, torch.Tensor) and v.requires_grad)  # This would screw up checkpointing.
         partial = functools.partial(self.wrap, **kwargs)
-        return torch.utils.checkpoint.checkpoint(partial, x, *args)
+        return torch.utils.checkpoint.checkpoint(partial, x, *args, use_reentrant=False)
 
 
 class CheckpointedXTransformerEncoder(nn.Module):

--- a/tortoise/models/xtransformers.py
+++ b/tortoise/models/xtransformers.py
@@ -970,15 +970,16 @@ class AttentionLayers(nn.Module):
 
             if layer_type == 'a':
                 out, inter, k, v = checkpoint(block, x, None, mask, None, attn_mask, self.pia_pos_emb, rotary_pos_emb,
-                                        prev_attn, layer_mem, layer_past)
+                                        prev_attn, layer_mem, layer_past, use_reentrant=False)
             elif layer_type == 'c':
                 if exists(full_context):
                     out, inter, k, v = checkpoint(block, x, full_context[cross_attn_count], mask, context_mask, None, None,
-                                            None, prev_attn, None, layer_past)
+                                            None, prev_attn, None, layer_past, use_reentrant=False)
                 else:
-                    out, inter, k, v = checkpoint(block, x, context, mask, context_mask, None, None, None, prev_attn, None, layer_past)
+                    out, inter, k, v = checkpoint(block, x, context, mask, context_mask, None, None, None, prev_attn, None, layer_past,
+                                                  use_reentrant=False)
             elif layer_type == 'f':
-                out = checkpoint(block, x)
+                out = checkpoint(block, x, use_reentrant=False)
 
             if layer_type == 'a' or layer_type == 'c' and present_key_values is not None:
                 present_key_values.append((k.detach(), v.detach()))


### PR DESCRIPTION
This fixes the warning `None of the inputs have requires_grad=True. Gradients will be None` that was generated every time TextToSpeech::tts was called. Not sure if this is the correct way to fix this tbh but it works fine in my testing.

Looking at the PyTorch docs [use_reentrant](https://pytorch.org/docs/1.11/checkpoint.html?highlight=use_reentrant) doesn't seem to exist prior to version 1.11.0 so if this is merged that would be the minimum required version for TorToiSe.