### PR TITLE
Documentation and Dependency Updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Next, install TorToiSe and it's dependencies:
 ```shell
 git clone https://github.com/neonbjb/tortoise-tts.git
 cd tortoise-tts
+python -m pip install -r ./requirements.txt
 python setup.py install
 ```
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,5 +8,10 @@ einops
 unidecode
 scipy
 librosa
+numpy==1.20.0
 numba==0.48.0
+torchaudio
 ffmpeg
+threadpoolctl
+llvmlite
+appdirs


### PR DESCRIPTION
This PR updates the dependencies such that `numpy` is locked at 1.20.0 to ensure that the project does not accidentally run afoul of the `numpy.long` deprecation. It also adds a few other dependencies that *appear* to be necessary for proper installation.

Additionally it updates the documentation such that the dependency requirements specified in `requirements.txt` are actually followed - when I used the `python setup.py install` directions, the version requirements in `requirements.txt` were not obeyed, and my environment just installed the latest version of all deps (including `number`), which I believe was causing issues similar to what was seen in [this issue](https://github.com/neonbjb/tortoise-tts/issues/240).