### PR TITLE
TextToSpeech to utilize passed device arg

### DIFF
--- a/tortoise/api.py
+++ b/tortoise/api.py
@@ -213,7 +213,9 @@ class TextToSpeech:
         self.models_dir = models_dir
         self.autoregressive_batch_size = pick_best_batch_size_for_gpu() if autoregressive_batch_size is None else autoregressive_batch_size
         self.enable_redaction = enable_redaction
-        self.device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
+        if device is None:
+            device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
+        self.device = device
         if self.enable_redaction:
             self.aligner = Wav2VecAlignment()
 


### PR DESCRIPTION
Started playing with the code and noticed that `device` isn't used in `tortois.api.TextToSpeech`.

Please let me know if that was intentional and there are some things to look for.