### PR TITLE
Remove FFMPEG dep

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,6 @@ librosa
 numpy==1.20.0
 numba==0.48.0
 torchaudio
-ffmpeg
 threadpoolctl
 llvmlite
 appdirs


### PR DESCRIPTION
Found while reviewing my code.

In retrospect I thought the necessity of the `ffmpeg` requirement from prior seemed odd. I had copied / pasted the req from someone else's thoughts on using `tortoise-tts`, and didn't question. After reviewing the dependencies I added to make sure they were all reasonably required within sub-projects, the `ffmpeg` dependency stood out as likely unnecessary ( Presuming it is [this library](https://github.com/jiashaokun/ffmpeg), it does not seem to actually be invoked by any libraries used in tortoise tts' operation ). 

My apologies for the bad suggestion here, removing the dependency to prevent any unnecessary inclusion.