### PR TITLE
Fixed typo error in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ inflect
 progressbar
 einops==0.4.1
 unidecode
-scipy==0.10.1
+scipy==1.10.1
 librosa==0.9.1
 numba==0.48.0
 ffmpeg


### PR DESCRIPTION
Fixed typo error in requirements.txt, scipy version should be 1.10.1 not 0.10.1. 
#374 #343 