### PR TITLE
Removes duplicate package "numba" in requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,6 @@ librosa==0.9.1
 numba==0.48.0
 ffmpeg
 numpy==1.20.0
-numba==0.48.0
 torchaudio
 threadpoolctl
 llvmlite


### PR DESCRIPTION
I was changing some other stuff in the requirements for my install and realised the package is listed twice so I removed the second copy of it.