### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,12 +6,11 @@ inflect
 progressbar
 einops==0.4.1
 unidecode
-scipy==1.10.1
+scipy
 librosa==0.9.1
-numba==0.48.0
 ffmpeg
-numpy==1.20.0
-numba==0.48.0
+numpy
+numba
 torchaudio
 threadpoolctl
 llvmlite


### PR DESCRIPTION
There was a double requirement line of numba and by my testing, the version requirements of scipy, numpy, and numba causes conflict and errors. Removing them fixes the problem in latest version of conda and python 3.10 (haven't tested on 3.11 because as far as I know, not all ML related packages are up to date with 3.11)