### PR TITLE
Update pydantic to 1.9.1 to fix ValueError

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,5 +17,5 @@ llvmlite
 appdirs
 nbconvert==5.3.1
 tornado==4.2
-pydantic==1.9.0
+pydantic==1.9.1
 deepspeed==0.8.3


### PR DESCRIPTION
Fixes this issue that I'm running into: https://stackoverflow.com/questions/72364077/pydantic-setting-a-default-value-for-an-annotated-type

Stacktrace with 1.9.0:
```
╰─ python tortoise/do_tts.py --text "I'm going to speak this" --preset fast                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              ─╯
Traceback (most recent call last):
  File "/Users/dc/code/tortoise-tts/tortoise/do_tts.py", line 7, in <module>
    from api import TextToSpeech, MODELS_DIR
  File "/Users/dc/code/tortoise-tts/tortoise/api.py", line 24, in <module>
    from tortoise.utils.tokenizer import VoiceBpeTokenizer
  File "/Users/dc/code/tortoise-tts/venv/lib/python3.9/site-packages/TorToiSe-2.4.2-py3.9.egg/tortoise/utils/tokenizer.py", line 4, in <module>
    import inflect
  File "/Users/dc/code/tortoise-tts/venv/lib/python3.9/site-packages/inflect/__init__.py", line 2054, in <module>
    class engine:
  File "/Users/dc/code/tortoise-tts/venv/lib/python3.9/site-packages/inflect/__init__.py", line 3791, in engine
    def number_to_words(  # noqa: C901
  File "pydantic/decorator.py", line 36, in pydantic.decorator.validate_arguments.validate
    import sys
  File "pydantic/decorator.py", line 126, in pydantic.decorator.ValidatedFunction.__init__
    try:
  File "pydantic/decorator.py", line 259, in pydantic.decorator.ValidatedFunction.create_model
    return fun
  File "pydantic/main.py", line 972, in pydantic.main.create_model
  File "pydantic/main.py", line 204, in pydantic.main.ModelMetaclass.__new__
  File "pydantic/fields.py", line 488, in pydantic.fields.ModelField.infer
  File "pydantic/fields.py", line 419, in pydantic.fields.ModelField.__init__
  File "pydantic/fields.py", line 534, in pydantic.fields.ModelField.prepare
  File "pydantic/fields.py", line 633, in pydantic.fields.ModelField._type_analysis
  File "pydantic/fields.py", line 776, in pydantic.fields.ModelField._create_sub_type
  File "pydantic/fields.py", line 451, in pydantic.fields.ModelField._get_field_info
ValueError: `Field` default cannot be set in `Annotated` for 'num_Annotated[str, FieldInfo(min_length=1, extra={})]'
```

No issue after 1.9.1 install.