### PR TITLE
bump minor version in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 setuptools.setup(
     name="TorToiSe",
     packages=setuptools.find_packages(),
-    version="2.4.2",
+    version="2.5.0",
     author="James Betker",
     author_email="james@adamant.ai",
     description="A high quality multi-voice text-to-speech library",


### PR DESCRIPTION
Noticed this when trying to install the repo as a package (pip fails to upgrade if it's the same).

Also some of the dependencies _might_ be added to setup.py, depending on how well they install. If they have installation problems, leaving them optional is a good choice as well.