### PR TITLE
Added MPS support

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -21,3 +21,4 @@ pydantic==1.9.1
 deepspeed==0.8.3
 py-cpuinfo
 hjson
+psutil

--- a/tortoise/api.py
+++ b/tortoise/api.py
@@ -100,7 +100,7 @@ def load_discrete_vocoder_diffuser(trained_diffusion_steps=4000, desired_diffusi
                            conditioning_free=cond_free, conditioning_free_k=cond_free_k)
 
 
-def format_conditioning(clip, cond_length=132300, device='cuda'):
+def format_conditioning(clip, cond_length=132300, device="cuda" if not torch.backends.mps.is_available() else 'mps'):
     """
     Converts the given conditioning signal to a MEL spectrogram and clips it as expected by the models.
     """

--- a/tortoise/models/arch_util.py
+++ b/tortoise/models/arch_util.py
@@ -319,6 +319,8 @@ class TorchMelSpectrogram(nn.Module):
         if len(inp.shape) == 3:  # Automatically squeeze out the channels dimension if it is present (assuming mono-audio)
             inp = inp.squeeze(1)
         assert len(inp.shape) == 2
+        if torch.backends.mps.is_available():
+            inp = inp.to('cpu')
         self.mel_stft = self.mel_stft.to(inp.device)
         mel = self.mel_stft(inp)
         # Perform dynamic range compression

--- a/tortoise/models/diffusion_decoder.py
+++ b/tortoise/models/diffusion_decoder.py
@@ -302,7 +302,10 @@ class DiffusionTts(nn.Module):
                 unused_params.extend(list(lyr.parameters()))
             else:
                 # First and last blocks will have autocast disabled for improved precision.
-                with autocast(x.device.type, enabled=self.enable_fp16 and i != 0):
+                if not torch.backends.mps.is_available():
+                    with autocast(x.device.type, enabled=self.enable_fp16 and i != 0):
+                        x = lyr(x, time_emb)
+                else:
                     x = lyr(x, time_emb)
 
         x = x.float()

--- a/tortoise/utils/audio.py
+++ b/tortoise/utils/audio.py
@@ -180,7 +180,7 @@ class TacotronSTFT(torch.nn.Module):
         return mel_output
 
 
-def wav_to_univnet_mel(wav, do_normalization=False, device='cuda'):
+def wav_to_univnet_mel(wav, do_normalization=False, device='cuda' if not torch.backends.mps.is_available() else 'mps'):
     stft = TacotronSTFT(1024, 256, 1024, 100, 24000, 0, 12000)
     stft = stft.to(device)
     mel = stft.mel_spectrogram(wav)

--- a/tortoise/utils/diffusion.py
+++ b/tortoise/utils/diffusion.py
@@ -1244,7 +1244,7 @@ def _extract_into_tensor(arr, timesteps, broadcast_shape):
                             dimension equal to the length of timesteps.
     :return: a tensor of shape [batch_size, 1, ...] where the shape has K dims.
     """
-    res = th.from_numpy(arr).to(device=timesteps.device)[timesteps].float()
+    res = th.from_numpy(arr.astype(np.float32)).to(device=timesteps.device)[timesteps]
     while len(res.shape) < len(broadcast_shape):
         res = res[..., None]
     return res.expand(broadcast_shape)

--- a/tortoise/utils/wav2vec_alignment.py
+++ b/tortoise/utils/wav2vec_alignment.py
@@ -49,7 +49,7 @@ class Wav2VecAlignment:
     """
     Uses wav2vec2 to perform audio<->text alignment.
     """
-    def __init__(self, device='cuda'):
+    def __init__(self, device='cuda' if not torch.backends.mps.is_available() else 'mps'):
         self.model = Wav2Vec2ForCTC.from_pretrained("jbetker/wav2vec2-large-robust-ft-libritts-voxpopuli").cpu()
         self.feature_extractor = Wav2Vec2FeatureExtractor.from_pretrained(f"facebook/wav2vec2-large-960h")
         self.tokenizer = Wav2Vec2CTCTokenizer.from_pretrained('jbetker/tacotron-symbols')


### PR DESCRIPTION
I managed to make the code work for `do_tts.py` and the `is_this_from_tortoise.py` on Apple Silicon. It takes the following times to generate a single phrase on various presets:

- ultra-fast: ~30secs.
- fast: ~1min
- standard: ~4mins.

I run the testing on my mac M1 Max with macOS 13.5. You need to have macOS 13.3+ to have int64 support on MPS. And you also need to use the nightly version of pytorch. Not all the operations are run in the GPU, I modified the code to fall back to CPU in some cases that gave errors. I also recommend running the code with `PYTORCH_ENABLE_MPS_FALLBACK=1`. In the future many more operations like the `aten::_fft_r2c` will have support in pytorch with MPS backend and so we can hope the inference times to get better, but for now, it is what it is.

## **Sidenote**

The classifier that detects whether a clip is generated or not can be easily fooled by re-recording the audio.
