### PR TITLE
fix(sec): upgrade nbconvert to 6.5.1-1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ torchaudio
 threadpoolctl
 llvmlite
 appdirs
-nbconvert==5.3.1
+nbconvert==6.5.1-1
 tornado==4.2
 pydantic==1.9.1
 deepspeed==0.8.3


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in nbconvert 5.3.1
- [CVE-2021-32862](https://www.oscs1024.com/hd/CVE-2021-32862)


### What did I do？
Upgrade nbconvert from 5.3.1 to 6.5.1-1 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### How can we automate the detection of these types of issues?
By using the [GitHub Actions](https://github.com/murphysecurity/actions) configurations provided by murphysec, we can conduct automatic code security checks in our CI pipeline.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS