### PR TITLE
Dockerfile - updated transformers version to 4.31.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,6 @@ SHELL ["/bin/bash", "--login", "-c"]
 RUN conda create --name tortoise python=3.9 numba inflect \
     && conda activate tortoise \
     && conda install pytorch torchvision torchaudio pytorch-cuda=11.7 -c pytorch -c nvidia \
-    && conda install transformers=4.29.2 \
+    && conda install transformers=4.31.0 \
     && cd /app \
     && python setup.py install


### PR DESCRIPTION
Building the docker image using `docker build . -t tts` didn't work for me, it gave the following error :
`error: tokenizers 0.15.1 is installed but tokenizers!=0.11.3,<0.14,>=0.11.1 is required by {'transformers'}`

 I checked `requirements.txt` and found that the required transformers version was 4.31.0 instead of 4.29.2. After updating that line in the Dockerfile, the `docker build` command worked.