### PR TITLE
Update Dockerfile to enable CUDA pytorch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ SHELL ["/bin/bash", "--login", "-c"]
 
 RUN conda create --name tortoise python=3.9 numba inflect \
     && conda activate tortoise \
-    && conda install pytorch torchvision torchaudio pytorch-cuda=11.7 -c pytorch -c nvidia \
+    && conda install pytorch==2.2.2 torchvision==0.17.2 torchaudio==2.2.2 pytorch-cuda=12.1 -c pytorch -c nvidia \
     && conda install transformers=4.31.0 \
     && cd /app \
     && python setup.py install


### PR DESCRIPTION
With the current Docker build, `conda` defaults to installing `pytorch` in CPU mode despite the use of pytorch and nvidia channels. This may be a change in how `conda` handles package relationships. The below command adjustment passes in the specific version numbers, which ensures that `conda` recognizes the use of `pytorch-cuda` as related, and properly installs the CUDA version of `pytorch`.

This can be validated after-the-fact with starting the container and running:
```bash
cd /app
conda activate tortoise
python -c "import torch; print(torch.cuda.is_available());torch.zeros(1).cuda()"
```

The current image returns an error, while after this PR, returns "True".

Note: This also updates CUDA in pytorch to 12.1 to better align to the CUDA docker image being used as the base.