### PR TITLE
setup.cfg: fix warning

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,2 @@
 [metadata]
-description-file = README.md
+description_file = README.md


### PR DESCRIPTION
setuptools is deprecating dash-separated options on 2024-09-26.  There's a banner when installing that warns about this.