### PR TITLE
adding a parameter check for device.

### DIFF
--- a/tortoise/api.py
+++ b/tortoise/api.py
@@ -194,7 +194,11 @@ class TextToSpeech:
         self.models_dir = models_dir
         self.autoregressive_batch_size = pick_best_batch_size_for_gpu() if autoregressive_batch_size is None else autoregressive_batch_size
         self.enable_redaction = enable_redaction
-        self.device = torch.device('cuda' if torch.cuda.is_available() else'cpu')
+        if device is None:
+            self.device = torch.device('cuda' if torch.cuda.is_available() else'cpu')
+        else:
+            self.device = torch.device(device)
+            
         if torch.backends.mps.is_available():
             self.device = torch.device('mps')
         if self.enable_redaction:

--- a/tortoise/api_fast.py
+++ b/tortoise/api_fast.py
@@ -193,7 +193,11 @@ class TextToSpeech:
         self.models_dir = models_dir
         self.autoregressive_batch_size = pick_best_batch_size_for_gpu() if autoregressive_batch_size is None else autoregressive_batch_size
         self.enable_redaction = enable_redaction
-        self.device = torch.device('cuda' if torch.cuda.is_available() else'cpu')
+        if device is None:
+            self.device = torch.device('cuda' if torch.cuda.is_available() else'cpu')
+        else:
+            self.device = torch.device(device)
+            
         if torch.backends.mps.is_available():
             self.device = torch.device('mps')
         if self.enable_redaction:


### PR DESCRIPTION
This fixes issue #776. 
Without this fix, you wouldn't be able to select cpu even if you wanted to use it in a system with both cpu and gpu. 

Also, for multi GPU systems, not being able to specify a GPU device will trigger cuda errors if the voice clips/inputs/model are loaded on separate devices. 